### PR TITLE
49 create convert static to state function

### DIFF
--- a/src/clearwater_modules/base.py
+++ b/src/clearwater_modules/base.py
@@ -151,7 +151,7 @@ class Model(CanRegisterVariable):
         data_arrays: dict[str, xr.DataArray] = {}
 
         for k, v in initial_state_values.items():
-            if k not in self.state_variables_names and k not in self.updateable_static_variables:
+            if k not in (self.state_variables_names + self.updateable_static_variables):
                 warnings.warn(
                     f'Variable {k} is not a state variable, skipping.',
                 )

--- a/src/clearwater_modules/tsm/processes.py
+++ b/src/clearwater_modules/tsm/processes.py
@@ -340,8 +340,9 @@ def ri_function(ri_number: xr.DataArray) -> np.ndarray:
     """
     warnings.filterwarnings("ignore", category=RuntimeWarning)
 
-    # note: conditions are evaluated in orderreturn
-    bounds: np.ndarray = np.select(
+    # NOTE: conditions are evaluated in the order of the original code
+    # TODO: refactor into a single set of conditions, once testing is in place
+    ri_number_bounded: np.ndarray = np.select(
         condlist=[
             ri_number > 2.0,
             ri_number < -1.0,
@@ -354,16 +355,16 @@ def ri_function(ri_number: xr.DataArray) -> np.ndarray:
     )
     out: np.ndarray = np.select(
         condlist=[
-            (bounds < 0.0) & (bounds >= -0.01),
-            (bounds < 0.0) & (bounds < -0.01),
-            (bounds >= 0.0) & (bounds <= 0.01),
-            (bounds >= 0.0) & (bounds > 0.01),
+            (ri_number_bounded < 0.0) & (ri_number_bounded >= -0.01), # neutral
+            (ri_number_bounded < 0.0) & (ri_number_bounded < -0.01),  # unstable
+            (ri_number_bounded >= 0.0) & (ri_number_bounded <= 0.01), # neutral
+            (ri_number_bounded >= 0.0) & (ri_number_bounded > 0.01),  # stable
         ],
         choicelist=[
-            1.0,
-            (1.0 - 22.0 * bounds) ** 0.80,
-            1.0,
-            (1.0 + 34.0 * bounds) ** (-0.80),
+            1.0,                                         # neutral
+            (1.0 - 22.0 * ri_number_bounded) ** 0.80,    # unstable
+            1.0,                                         # neutral
+            (1.0 + 34.0 * ri_number_bounded) ** (-0.80), # stable
         ],
     )
     warnings.filterwarnings("default", category=RuntimeWarning)

--- a/src/clearwater_modules/tsm/processes.py
+++ b/src/clearwater_modules/tsm/processes.py
@@ -341,23 +341,30 @@ def ri_function(ri_number: xr.DataArray) -> np.ndarray:
     warnings.filterwarnings("ignore", category=RuntimeWarning)
 
     # note: conditions are evaluated in orderreturn
-    out: np.ndarray = np.select(
+    bounds: np.ndarray = np.select(
         condlist=[
             ri_number > 2.0,
             ri_number < -1.0,
-            (ri_number < 0.0) & (ri_number >= -0.01),
-            ri_number < -0.01,
-            (ri_number >= 0.0) & (ri_number <= 0.01),
-
         ],
         choicelist=[
-            (1.0 + (34.0 * 2.0)) ** (-0.80),
-            (1.0 - (22.0 * (-1.0))) ** (-0.80),
-            1.0,
-            (1.0 - 22.0 * ri_number) ** 0.80,
-            1.0,
+            2.0,
+            -1.0,
         ],
-        default=(1.0 + 34.0 * ri_number) ** (-0.80),
+        default=ri_number,
+    )
+    out: np.ndarray = np.select(
+        condlist=[
+            (bounds < 0.0) & (bounds >= -0.01),
+            (bounds < 0.0) & (bounds < -0.01),
+            (bounds >= 0.0) & (bounds <= 0.01),
+            (bounds >= 0.0) & (bounds > 0.01),
+        ],
+        choicelist=[
+            1.0,
+            (1.0 - 22.0 * bounds) ** 0.80,
+            1.0,
+            (1.0 + 34.0 * bounds) ** (-0.80),
+        ],
     )
     warnings.filterwarnings("default", category=RuntimeWarning)
     return out

--- a/src/clearwater_modules/utils.py
+++ b/src/clearwater_modules/utils.py
@@ -28,14 +28,14 @@ def validate_arrays(array: xr.DataArray, *args: xr.DataArray) -> None:
 
 @numba.jit(forceobj=True)
 def iter_computations(
-    input_array: xr.DataArray,
+    input_dataset: xr.Dataset,
     compute_order: list[Variable],
-) -> xr.DataArray:
+) -> xr.Dataset:
     """Iterate over the computation order."""
     for var in compute_order:
         input_vars: list[str] = sorter.get_process_args(var.process)
-        input_array[var.name] = xr.apply_ufunc(
+        input_dataset[var.name] = xr.apply_ufunc(
             var.process,
-            *[input_array[name] for name in input_vars],
+            *[input_dataset[name] for name in input_vars],
         )
-    return input_array
+    return input_dataset


### PR DESCRIPTION
Closes #49 

**Changes:**
* I looped back to fix the logic for TSM's `ri_function` using two-step logic following a misunderstanding in my last PR @aufdenkampe 
* I created the feature discussed in Issue #49 where one can init a Model with an optional list of static variable names, `updateable_static_variables` that allow them to be updated between timesteps (essentially gives them a time dimension). See example below
* I used `pyright` (a handy command line tool) to fix a few unaligned type hints
* I added test coverage for the new static variable update feature -> all tests are passing

@sjordan29 @jrutyna You can now proceed as discussed.

For example, imagine a model with a 1 state variable called "state_variable_1" and two static variables "static_1" and "static_2".
Despite the static variables not being changed by the model itself (hence why they are called static), one might want to alter "static_1" between running timesteps via another model like `Clearwater-Riverine`. To do so you simply init the model as shown below:

```python
import clearwater_modules.base as base

my_model_instance: base.Model = Model(
     initial_state_values={'state_variable_1': 1.0},
     updateable_static_variables=['static_1']
)
```

then when running a timestep you can use the `update_state_values` argument, which takes a dictionary with variable names as keys, and `xr.DataArrays` as values. For now, this requires data arrays, but I am going to open a new issue to support just passing in a number, and having that number broadcast to the shape of our `xr.Dataset`, see #52 .
