### PR TITLE
Bug fix for EnergyBudget

### DIFF
--- a/src/clearwater_modules/tsm/model.py
+++ b/src/clearwater_modules/tsm/model.py
@@ -19,6 +19,7 @@ class EnergyBudget(base.Model):
     def __init__(
         self,
         initial_state_values: Optional[base.InitialVariablesDict] = None,
+        updateable_static_variables: Optional[list[str]] = None,
         meteo_parameters: Optional[dict[str, float]] = None,
         temp_parameters: Optional[dict[str, float]] = None,
         track_dynamic_variables: bool = True,
@@ -55,6 +56,7 @@ class EnergyBudget(base.Model):
         super().__init__(
             initial_state_values=initial_state_values,
             static_variable_values=static_variable_values,
+            updateable_static_variables=updateable_static_variables,
             track_dynamic_variables=track_dynamic_variables,
             hotstart_dataset=hotstart_dataset,
             time_dim=time_dim,

--- a/tests/test_4_tsm_module.py
+++ b/tests/test_4_tsm_module.py
@@ -31,6 +31,7 @@ def energy_budget_instance(initial_tsm_state) -> EnergyBudget:
     """Return an instance of the TSM class."""
     return EnergyBudget(
         initial_state_values=initial_tsm_state,
+        updateable_static_variables=['a0'],
         time_dim='tsm_time_step',
     )
 
@@ -40,6 +41,7 @@ def test_tsm_specific_attributes(energy_budget_instance) -> None:
     assert energy_budget_instance.time_dim == 'tsm_time_step'
     assert isinstance(energy_budget_instance.met_parameters, dict)
     assert isinstance(energy_budget_instance.temp_parameters, dict)
+    assert energy_budget_instance.updateable_static_variables == ['a0']
     assert energy_budget_instance.met_parameters == DEFAULT_METEOROLOGICAL
     assert energy_budget_instance.temp_parameters == DEFAULT_TEMPERATURE
 


### PR DESCRIPTION
Closes #54 

@sjordan29 
Quick fix, basically forgot to add it to `super().__init__` in the `EnergyBudget` subclass of `base.Model`.

I also included it in the test coverage, albeit in a simplistic way.